### PR TITLE
Fix spread calculation when order book empty

### DIFF
--- a/src/components/OrderBook.tsx
+++ b/src/components/OrderBook.tsx
@@ -35,10 +35,12 @@ export function OrderBook({ orderBook, onPlaceOrder }: OrderBookProps) {
       {/* Spread Indicator */}
       <div className="text-center py-2 text-sm text-gray-500">
         Spread: $
-        {(
-          Math.min(...orderBook.asks.map(a => a.price)) -
-          Math.max(...orderBook.bids.map(b => b.price))
-        ).toFixed(2)}
+        {orderBook.asks.length && orderBook.bids.length
+          ? (
+              Math.min(...orderBook.asks.map((a) => a.price)) -
+              Math.max(...orderBook.bids.map((b) => b.price))
+            ).toFixed(2)
+          : 'N/A'}
       </div>
 
       {/* Bids (Buy Orders) */}


### PR DESCRIPTION
## Summary
- avoid invalid spread by checking if bids and asks exist

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851749b8774832cb77953ab79ddb2f4